### PR TITLE
This patch fixes the undesired SMACK label (SMACK64IPIN)  update

### DIFF
--- a/security/smack/smack_lsm.c
+++ b/security/smack/smack_lsm.c
@@ -2309,6 +2309,18 @@ static int smack_sk_alloc_security(struct sock *sk, int family, gfp_t gfp_flags)
  */
 static void smack_sk_free_security(struct sock *sk)
 {
+	struct smk_port_label *spp;
+	
+	if (sk->sk_family == PF_INET6) {
+		rcu_read_lock();
+		list_for_each_entry_rcu(spp, &smk_ipv6_port_list, list) {
+			if (spp->smk_sock != sk)
+				continue;
+			spp->smk_can_reuse = 1;
+			break;
+		}
+		rcu_read_unlock();
+        }
 	kfree(sk->sk_security);
 }
 
@@ -2588,10 +2600,15 @@ static void smk_ipv6_port_label(struct socket *sock, struct sockaddr *address)
 	list_for_each_entry(spp, &smk_ipv6_port_list, list) {
 		if (spp->smk_port != port)
 			continue;
+		if (spp->smk_can_reuse != 1) {
+			rcu_read_unlock();
+			return;
+		}
 		spp->smk_port = port;
 		spp->smk_sock = sk;
 		spp->smk_in = ssp->smk_in;
 		spp->smk_out = ssp->smk_out;
+		spp->smk_can_reuse = 0;
 		return;
 	}
 
@@ -2606,6 +2623,7 @@ static void smk_ipv6_port_label(struct socket *sock, struct sockaddr *address)
 	spp->smk_sock = sk;
 	spp->smk_in = ssp->smk_in;
 	spp->smk_out = ssp->smk_out;
+	spp->smk_can_reuse = 0;
 
 	list_add(&spp->list, &smk_ipv6_port_list);
 	return;


### PR DESCRIPTION
This patch fixes the undesired SMACK label (SMACK64IPIN)
 update when a second bind call is made to same IP address & port, but with
 different SMACK label (SMACK64IPIN) by second instance of server. In this
 case server returns with "Bind:Address already in use" error but before
 returning, SMACK label is updated in SMACK port-label mapping list inside
 "smack_socket_bind()" hook.

To fix the issue a new check has been added in smk_ipv6_port_label() function
before updating the existing port entry. It checks whether the socket for corresponding
port entry is closed or not. If it is closed then it means port is not bound and it is
safe to update the existing port entry else return if port is still getting used.
For checking whether socket is closed or not, one more field "smk_can_reuse" has been
added in the "smk_port_label" structure. This field will be set to '1' in "smack_sk_free_security()"
function which is called to free the socket security blob when the socket is being closed.
In this function, port entry is searched in the SMACK port-label mapping list for the closing socket.
If entry is found then "smk_can_reuse" field is set to '1'.Initially "smk_can_reuse" field is
set to '0' in smk_ipv6_port_label() function after creating a new entry in the list which
indicates that socket is in use.

Changelist Id:- 7691868d9f8615d97d90794de1e06970f8575c48
Signed-off-by: Vishal Goel vishal.goel@samsung.com
Signed-off-by: Himanshu Shukla himanshu.sh@samsung.com
